### PR TITLE
Update links to code of conduct in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ To install this gem onto your local machine, run `bundle exec rake install`.
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/cbroult/jira-auto-tool. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/[USERNAME]/jira-auto-tool/blob/master/CODE_OF_CONDUCT.md).
+Bug reports and pull requests are welcome on GitHub at https://github.com/cbroult/jira-auto-tool. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/[USERNAME]/jira-auto-tool/blob/main/CODE_OF_CONDUCT.md).
 
 ## License
 
@@ -220,4 +220,4 @@ The gem is available as open source under the terms of the [MIT License](https:/
 
 ## Code of Conduct
 
-Everyone interacting in the Jira::Sprint::Tool project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/jira-auto-tool/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the Jira::Sprint::Tool project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/jira-auto-tool/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
Fix links as the default branch was moved from master to main